### PR TITLE
Configurable Game Tickrate (env + docker)

### DIFF
--- a/back/src/ecs/entity/Car.ts
+++ b/back/src/ecs/entity/Car.ts
@@ -180,7 +180,7 @@ export class Car {
     )
 
     const proximityPromptComponent = new ProximityPromptComponent(this.entity.id, {
-      text: 'Enter/Exit',
+      text: 'Enter',
       onInteract: (playerEntity) => {
         VehicleSystem.handleProximityPrompt(this.entity, playerEntity)
       },

--- a/back/src/ecs/system/network/WebsocketSystem.ts
+++ b/back/src/ecs/system/network/WebsocketSystem.ts
@@ -9,6 +9,7 @@ import {
 } from 'uWebSockets.js'
 import { unpack } from 'msgpackr'
 import { RateLimiterMemory } from 'rate-limiter-flexible'
+import { config } from '../../../../../shared/network/config.js'
 
 import { EntityDestroyedEvent } from '../../../../../shared/component/events/EntityDestroyedEvent.js'
 import {
@@ -146,6 +147,7 @@ export class WebsocketSystem {
     const connectionMessage: ConnectionMessage = {
       t: ServerMessageType.FIRST_CONNECTION,
       id: player.entity.id,
+      tickRate: config.SERVER_TICKRATE,
     }
     // player.entity.addComponent(new RandomizeComponent(player.entity.id))
     ws.player = player

--- a/back/src/sandbox.ts
+++ b/back/src/sandbox.ts
@@ -1,3 +1,4 @@
+import 'dotenv/config'
 import { readFile } from 'fs/promises'
 import { Script, createContext } from 'node:vm'
 import { resolve } from 'path'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,6 +43,9 @@ services:
     image: ghcr.io/iercann/notblox-game-server:latest
     labels:
       - com.centurylinklabs.watchtower.enable=true
+    environment:
+      - GAME_SCRIPT=defaultScript.js
+      - GAME_TICKRATE=60 # Higher tickrate for vehicles
     ports:
       - '8001:8001'
     volumes:
@@ -60,6 +63,7 @@ services:
       - com.centurylinklabs.watchtower.enable=true
     environment:
       - GAME_SCRIPT=parkourScript.js
+      - GAME_TICKRATE=20 # Default tickrate
     ports:
       - '8002:8001'
     volumes:
@@ -77,6 +81,7 @@ services:
       - com.centurylinklabs.watchtower.enable=true
     environment:
       - GAME_SCRIPT=footballScript.js
+      - GAME_TICKRATE=20 # Default tickrate
     ports:
       - '8003:8001'
     volumes:

--- a/front/game/WebsocketManager.ts
+++ b/front/game/WebsocketManager.ts
@@ -3,9 +3,10 @@ import { ServerMessage, ServerMessageType } from '@shared/network/server/base'
 import { SnapshotMessage } from '@shared/network/server/serialized'
 import { Game } from './game'
 import { ConnectionMessage } from '@shared/network/server/connection'
-import { ClientMessage, ClientMessageType } from '@shared/network/client/base'
+import { ClientMessage } from '@shared/network/client/base'
 import { isNativeAccelerationEnabled } from 'msgpackr'
 import pako from 'pako'
+import { config } from '@shared/network/config'
 
 if (!isNativeAccelerationEnabled)
   console.warn('Native acceleration not enabled, verify that install finished properly')
@@ -26,7 +27,10 @@ export class WebSocketManager {
     this.addMessageHandler(ServerMessageType.FIRST_CONNECTION, (message) => {
       const connectionMessage = message as ConnectionMessage
       game.currentPlayerEntityId = connectionMessage.id
-      console.log('first connection', game.currentPlayerEntityId)
+      config.SERVER_TICKRATE = connectionMessage.tickRate
+      console.log(
+        `Connected to server with player ID: ${game.currentPlayerEntityId}, server tick rate: ${connectionMessage.tickRate}`
+      )
     })
 
     this.addMessageHandler(ServerMessageType.SNAPSHOT, (message) => {

--- a/front/game/ecs/system/SyncPositionSystem.ts
+++ b/front/game/ecs/system/SyncPositionSystem.ts
@@ -2,20 +2,24 @@ import * as THREE from 'three'
 import { Entity } from '@shared/entity/Entity'
 import { MeshComponent } from '../component/MeshComponent'
 import { PositionComponent } from '@shared/component/PositionComponent'
-
+import { VehicleComponent } from '@shared/component/VehicleComponent'
 export class SyncPositionSystem {
   update(entities: Entity[], interpolationFactor: number) {
     for (const entity of entities) {
       const meshComponent = entity.getComponent(MeshComponent)
       const positionComponent = entity.getComponent(PositionComponent)
-
+      const vehicleComponent = entity.getComponent(VehicleComponent)
       if (meshComponent && positionComponent) {
         const targetPosition = new THREE.Vector3(
           positionComponent.x,
           positionComponent.y,
           positionComponent.z
         )
-        meshComponent.mesh.position.lerp(targetPosition, interpolationFactor)
+        // Smooth vehicle more than other entities
+        meshComponent.mesh.position.lerp(
+          targetPosition,
+          vehicleComponent ? 0.1 : interpolationFactor
+        )
       }
     }
   }

--- a/front/game/ecs/system/SyncRotationSystem.ts
+++ b/front/game/ecs/system/SyncRotationSystem.ts
@@ -2,13 +2,13 @@ import * as THREE from 'three'
 import { Entity } from '@shared/entity/Entity'
 import { MeshComponent } from '../component/MeshComponent'
 import { RotationComponent } from '@shared/component/RotationComponent'
-import { SerializedEntityType } from '@shared/network/server/serialized'
-
+import { VehicleComponent } from '@shared/component/VehicleComponent'
 export class SyncRotationSystem {
   update(entities: Entity[], interpolationFactor: number) {
     for (const entity of entities) {
       const meshComponent = entity.getComponent(MeshComponent)
       const rotationComponent = entity.getComponent(RotationComponent)
+      const vehicleComponent = entity.getComponent(VehicleComponent)
 
       if (meshComponent && rotationComponent) {
         const targetQuaternion = new THREE.Quaternion(
@@ -19,11 +19,10 @@ export class SyncRotationSystem {
         )
 
         // Interpolate rotation using slerp (spherical linear interpolation)
-        if (entity.type === SerializedEntityType.VEHICLE) {
-          meshComponent.mesh.quaternion.slerp(targetQuaternion, interpolationFactor / 2)
-        } else {
-          meshComponent.mesh.quaternion.slerp(targetQuaternion, interpolationFactor)
-        }
+        meshComponent.mesh.quaternion.slerp(
+          targetQuaternion,
+          vehicleComponent ? 0.5 : interpolationFactor
+        )
       }
     }
   }

--- a/shared/network/config.ts
+++ b/shared/network/config.ts
@@ -3,6 +3,12 @@ const isServer =
   typeof process !== 'undefined' && process.versions != null && process.versions.node != null
 
 export const config = {
-  SERVER_TICKRATE: 20, // SERVER
+  /**
+   * The server's tickrate is determined by the GAME_TICKRATE environment variable, defaulting to 20 if not set.
+   * The client initially uses a default tickrate of 20, but this is updated when receiving the first
+   * connection message from the server to match the server's actual tickrate.
+   * See the ConnectionMessage type in connection.ts for details.
+   */
+  SERVER_TICKRATE: isServer ? Number(process.env.GAME_TICKRATE) || 20 : 20,
   IS_SERVER: isServer,
 }

--- a/shared/network/server/connection.ts
+++ b/shared/network/server/connection.ts
@@ -3,4 +3,6 @@ import { ServerMessage } from './base'
 export interface ConnectionMessage extends ServerMessage {
   // Connected player entity id
   id: number
+  // Server tick rate in Hz
+  tickRate: number
 }


### PR DESCRIPTION
# Configurable Game Tickrate

## Changes
- Added configurable tickrate support through environment variables
- Added tickrate synchronization between server and client via connection message
- Updated docker-compose.yml with tickrate configuration for each game type
- Smoothed vehicle a bit with more interpolation

## Technical Details
1. Server-side:
   - Reads `GAME_TICKRATE` from environment variables (defaults to 20)
   - Sends the tickrate to clients in the initial connection message
   - Physics system uses this value for simulation timesteps

2. Client-side:
   - Starts with default tickrate of 20
   - Updates its tickrate when receiving the connection message from server
   - Uses synchronized tickrate for position interpolation

3. Configuration:
   - Test server: 60 Hz (higher tickrate for better vehicle physics)
   - Parkour server: 20 Hz (default tickrate sufficient for platforming)
   - Football server: 20 Hz (default tickrate sufficient for gameplay)
